### PR TITLE
Changed sample_ppc to the newer PyMC3 method

### DIFF
--- a/pmlearn/linear_model/base.py
+++ b/pmlearn/linear_model/base.py
@@ -110,7 +110,7 @@ class BayesianLinearClassifierMixin(ClassifierMixin):
             'model_cats': cats
         })
 
-        ppc = pm.sample_ppc(self.trace, model=self.cached_model, samples=2000)
+        ppc = pm.sample_posterior_predictive(self.trace, model=self.cached_model, samples=2000)
 
         if return_std:
             return ppc['y'].mean(axis=0), ppc['y'].std(axis=0)


### PR DESCRIPTION
Just one tiny change. Changed the pm dot sample_ppc to pm dot sample_posterior_predictive method introduced in newer PyMC3 v3.6+

**Full Disclosure** : I'm very new to Bayesian statistics so it might be possible I don't know what I'm talking about. 

Anyway, I was trying to work through the [tutorials](https://pymc-learn.readthedocs.io/en/latest/regression.html) from the site and specifically the one on [bayesian linear regression](https://pymc-learn.readthedocs.io/en/latest/notebooks/LinearRegression.html). 
I got stuck at model.predict as I kept getting this error

```
AttributeError                            Traceback (most recent call last)
<ipython-input-15-f3f0823146e6> in <module>()
----> 1 y_predict = model.predict(X_test)

/usr/local/lib/python3.6/dist-packages/pmlearn/base.py in predict(self, X, return_std)
    277                                'model_output': np.zeros(num_samples)})
    278 
--> 279         ppc = pm.sample_ppc(self.trace, model=self.cached_model, samples=2000)
    280 
    281         if return_std:

AttributeError: module 'pymc3' has no attribute 'sample_ppc'
``` 
Upon Googling, found this [issue](https://github.com/pymc-devs/pymc3/issues/3243) and as far as I understand, `sample_ppc `is now `sample_posterior_predictive`. So that's all I changed. 

**Platforms and Versions**

Tried this only on the Google Colab VM. 
```
import pmlearn
import pymc3 as pm

pmlearn.__version__
0.0.1.rc3
pm.__version__
3.9.3 
```