### PR TITLE
Optimizing test

### DIFF
--- a/pmlearn/gaussian_process/tests/test_gpr.py
+++ b/pmlearn/gaussian_process/tests/test_gpr.py
@@ -88,7 +88,7 @@ class TestGaussianProcessRegressorPredict(TestGaussianProcessRegressor):
     def test_predict_returns_predictions(self):
         print('')
         self.advi_gpr.fit(self.X_train, self.y_train,
-                          inference_args={"n": 25000})
+                          inference_args={"n": 200})
         preds = self.advi_gpr.predict(self.X_test)
         npt.assert_equal(self.y_test.shape, preds.shape)
 


### PR DESCRIPTION
Hi,

I was able to reduce the running time of `TestGaussianProcessRegressorPredict::test_predict_returns_predictions` test from 236  seconds to about 52 seconds on my local machine by changing `n` to 200.

I also ran the test several times to ensure that the test is not flaky.

Environment:
```
python 3.8.5
pymc3==3.4.1
numpy==1.19.5
```
Is this something that you guys will be interested in? If yes, then I can help you optimize some other tests in this repo as well. If you have any other suggestions/edits I will be happy to integrate them as well. Please let me know.

Thanks!